### PR TITLE
Correctly interpret patterns beggining with !

### DIFF
--- a/lib/multi-glob.js
+++ b/lib/multi-glob.js
@@ -14,7 +14,10 @@ function resolveGlobs(patterns, options) {
                 if (!err && options.strict && matches.length === 0) {
                     done(new Error("'" + pattern + "' matched no files"));
                 } else {
-                    done(err, matches);
+                    done(err, {
+                        action: pattern[0] === '!' ? 'exclude' : 'include',
+                        matches: matches
+                    });
                 }
             });
         });
@@ -24,7 +27,21 @@ function resolveGlobs(patterns, options) {
 
 function processSingle(callback) {
     return function (err, matches) {
-        callback(err, _.uniq(_.flatten(_.toArray(matches))));
+        matches = _.toArray(matches);
+        var includes = _.flatten(matches.filter(function(match) {
+            return match && match.action === 'include';
+        }).map(function(match) {
+            return match.matches;
+        }));
+
+        var excludes = _.flatten(matches.filter(function(match) {
+            return match && match.action === 'exclude';
+        }).map(function(match) {
+            return match.matches;
+        }));
+
+        var finalMatches = _.difference(includes, excludes);
+        callback(err, _.uniq(finalMatches));
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "multi-glob",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Small wrapper around the glob module that allows globbing for multiple patterns at once",
     "homepage": "http://busterjs.org/docs/modules/multi-glob",
     "author": "Christian Johansen",

--- a/test/multi-glob-test.js
+++ b/test/multi-glob-test.js
@@ -100,6 +100,17 @@ buster.testCase("Multi-glob", {
         assert.calledWith(callback, undefined, ["src/foo.js", "src/bar.js"]);
     },
 
+    "Ignore patterns beggining with !": function () {
+        var callback = this.spy();
+        glob.glob.withArgs("!src/foo.js").yields(null, ["src/foo.js"]);
+        var files = ["src/foo.js", "src/bar.js"];
+        glob.glob.withArgs("src/*.js").yields(null, files);
+
+        g.glob(["src/*.js", "!src/foo.js"], callback);
+
+        assert.calledWith(callback, undefined, ["src/bar.js"]);
+    },
+
     "strict": {
         "fails on glob that matches no patterns": function () {
             var callback = this.spy();


### PR DESCRIPTION
These patterns were treated as the others, and thus, there was no way to exclude some files or folders.