### PR TITLE
Replace lodash dependency with native reduce and filter implementations

### DIFF
--- a/lib/multi-glob.js
+++ b/lib/multi-glob.js
@@ -1,6 +1,5 @@
 var glob = require("glob");
 var async = require("async");
-var _ = require("lodash");
 
 function array(arr) {
     return Array.isArray(arr) ? arr : [arr];
@@ -24,7 +23,13 @@ function resolveGlobs(patterns, options) {
 
 function processSingle(callback) {
     return function (err, matches) {
-        callback(err, _.uniq(_.flatten(_.toArray(matches))));
+        var results = matches.reduce(function (flattened, match) {
+                return Array.isArray(match) ? flattened.concat(match) : flattened;
+            }, [])
+            .filter(function (match, i, flattened) {
+                return flattened.indexOf(match) === i;
+            });
+        callback(err, results);
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "glob": "5.x",
-    "async": "1.x",
-    "lodash": "3.x"
+    "async": "1.x"
   },
   "devDependencies": {
     "buster": "*",


### PR DESCRIPTION
The `lodash` dependency was only used to flatten and deduplicate results. These two mutations on an array are quite easily expressed using Array#reduce and Array#filter. By adding a little extra code in lib/multi-glob.js we can drop the dependency on lodash, which is principally better.

Deduplicating results was already tested. If flattening results does not work, multiple tests will fail. For this reason I have not added new tests.